### PR TITLE
Further adjustments to Makefile, and fixes for /usr/local prefix

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -36,7 +36,7 @@ struct Error {
 };
 ```
 
-The return value of functions is either an poiinter to `error_stack` or `NULL` (no error).
+The return value of functions is either a pointer to `error_stack` or `NULL` (no error).
 
 ### memory.c
 

--- a/Makefile
+++ b/Makefile
@@ -1,33 +1,51 @@
-PREFIX=/usr/local
+PREFIX   = /usr/local
 
-confdir = $(PREFIX)/etc
-bindir =  $(PREFIX)/bin
+bindir   = $(PREFIX)/bin
+confdir  = $(PREFIX)/etc
+libdir   = $(PREFIX)/lib
 sharedir = $(PREFIX)/share
 
-CFLAGS_MAIN = $(CCFLAGS) -DCONFDIR=\"$(confdir)\" -DDATADIR=\"$(sharedir)\"
+ifeq ($(BUILD), debug)
+	CFLAGS   = -Og -g
+else
+	CPPFLAGS = -DNDEBUG
+	CFLAGS   = -Os
+	LDFLAGS  = -s
+endif
 
-PROGS = src/nbfc_service src/ec_probe #src/nbfc
+override LDLIBS   += -lm
+override CPPFLAGS += -DCONFDIR=\"$(confdir)\" -DDATADIR=\"$(sharedir)\"
+
+CORE  = src/nbfc_service src/ec_probe
+PROGS = $(CORE) src/nbfc
 
 all: $(PROGS)
 
-install-systemd: etc/systemd/system/nbfc_service.service
-	# /etc/systemd/system
-	install -Dm 644 etc/systemd/system/nbfc_service.service $(DESTDIR)$(confdir)/systemd/system/nbfc_service.service
+install-systemd:
+	# /usr/local/lib/systemd/system
+	install -Dm 644 etc/systemd/system/nbfc_service.service $(DESTDIR)$(libdir)/systemd/system/nbfc_service.service
 
-install-bin: $(PROGS)
-	install -Dm 755 nbfc.py   $(DESTDIR)$(bindir)/nbfc
+install-core: $(CORE)
 	install -Dm 755 src/nbfc_service  $(DESTDIR)$(bindir)/nbfc_service
 	install -Dm 755 src/ec_probe      $(DESTDIR)$(bindir)/ec_probe
-	#install -Dm 755 src/nbfc         $(DESTDIR)$(bindir)/nbfc   #client written in c
+
+install-client-py:
+	install -Dm 755 nbfc.py           $(DESTDIR)$(bindir)/nbfc
+
+install-client-c:   src/nbfc
+	install -Dm 755 src/nbfc          $(DESTDIR)$(bindir)/nbfc
 
 install-configs:
-	# /usr/share/nbfc/configs
+	# /usr/local/etc/nbfc
+	mkdir -p $(DESTDIR)$(confdir)/nbfc
+
+	# /usr/local/share/nbfc/configs
 	mkdir -p $(DESTDIR)$(sharedir)/nbfc/configs
 	cp -r share/nbfc/configs/* $(DESTDIR)$(sharedir)/nbfc/configs
 
 install-docs:
-	install -Dm 644 doc/ec_probe.1   $(DESTDIR)$(sharedir)/man/man1/ec_probe.1
-	install -Dm 644 doc/nbfc.1       $(DESTDIR)$(sharedir)/man/man1/nbfc.1
+	install -Dm 644 doc/ec_probe.1            $(DESTDIR)$(sharedir)/man/man1/ec_probe.1
+	install -Dm 644 doc/nbfc.1                $(DESTDIR)$(sharedir)/man/man1/nbfc.1
 	install -Dm 644 doc/nbfc_service.1        $(DESTDIR)$(sharedir)/man/man1/nbfc_service.1
 	install -Dm 644 doc/nbfc_service.json.5   $(DESTDIR)$(sharedir)/man/man5/nbfc_service.json.5
 
@@ -45,38 +63,43 @@ install-completion:
 	cp completion/fish/nbfc_service.fish   $(DESTDIR)$(sharedir)/fish/completions/
 	cp completion/fish/ec_probe.fish       $(DESTDIR)$(sharedir)/fish/completions/
 
-install: install-bin install-systemd install-configs install-docs install-completion
+install: install-core install-client-py install-systemd install-configs install-docs install-completion
+
+install-c: install-core install-client-c install-systemd install-configs install-docs install-completion
 
 uninstall:
 	# Binaries
-	rm $(DESTDIR)$(bindir)/nbfc
-	rm $(DESTDIR)$(bindir)/nbfc_service
-	rm $(DESTDIR)$(bindir)/ec_probe
+	rm -f $(DESTDIR)$(bindir)/nbfc
+	rm -f $(DESTDIR)$(bindir)/nbfc_service
+	rm -f $(DESTDIR)$(bindir)/ec_probe
 	
-	# /etc/systemd/system
-	rm $(DESTDIR)$(confdir)/systemd/system/nbfc_service.service
+	# /usr/local/lib/systemd/system
+	rm -f $(DESTDIR)$(libdir)/systemd/system/nbfc_service.service
 	
-	# /usr/share/nbfc/configs
-	rm -r $(DESTDIR)$(sharedir)/nbfc
+	# /usr/local/share/nbfc/configs
+	rm -rf $(DESTDIR)$(sharedir)/nbfc
+	
+	# /usr/local/etc/nbfc
+	rm -rf $(DESTDIR)$(confdir)/nbfc
 	
 	# Documentation
-	rm $(DESTDIR)$(sharedir)/man/man1/ec_probe.1
-	rm $(DESTDIR)$(sharedir)/man/man1/nbfc.1
-	rm $(DESTDIR)$(sharedir)/man/man1/nbfc_service.1
-	rm $(DESTDIR)$(sharedir)/man/man5/nbfc_service.json.5
+	rm -f $(DESTDIR)$(sharedir)/man/man1/ec_probe.1
+	rm -f $(DESTDIR)$(sharedir)/man/man1/nbfc.1
+	rm -f $(DESTDIR)$(sharedir)/man/man1/nbfc_service.1
+	rm -f $(DESTDIR)$(sharedir)/man/man5/nbfc_service.json.5
 	
 	# Completion
-	rm $(DESTDIR)$(sharedir)/zsh/site-functions/_nbfc
-	rm $(DESTDIR)$(sharedir)/zsh/site-functions/_nbfc_service
-	rm $(DESTDIR)$(sharedir)/zsh/site-functions/_ec_probe
+	rm -f $(DESTDIR)$(sharedir)/zsh/site-functions/_nbfc
+	rm -f $(DESTDIR)$(sharedir)/zsh/site-functions/_nbfc_service
+	rm -f $(DESTDIR)$(sharedir)/zsh/site-functions/_ec_probe
 	
-	rm $(DESTDIR)$(sharedir)/bash-completion/completions/nbfc
-	rm $(DESTDIR)$(sharedir)/bash-completion/completions/nbfc_service
-	rm $(DESTDIR)$(sharedir)/bash-completion/completions/ec_probe
+	rm -f $(DESTDIR)$(sharedir)/bash-completion/completions/nbfc
+	rm -f $(DESTDIR)$(sharedir)/bash-completion/completions/nbfc_service
+	rm -f $(DESTDIR)$(sharedir)/bash-completion/completions/ec_probe
 	 
-	rm $(DESTDIR)$(sharedir)/fish/completions/nbfc.fish
-	rm $(DESTDIR)$(sharedir)/fish/completions/nbfc_service.fish
-	rm $(DESTDIR)$(sharedir)/fish/completions/ec_probe.fish
+	rm -f $(DESTDIR)$(sharedir)/fish/completions/nbfc.fish
+	rm -f $(DESTDIR)$(sharedir)/fish/completions/nbfc_service.fish
+	rm -f $(DESTDIR)$(sharedir)/fish/completions/ec_probe.fish
 
 clean:
 	rm -rf __pycache__ tools/argparse-tool/__pycache__
@@ -112,7 +135,7 @@ src/nbfc_service: \
 	src/temperature_filter.c src/temperature_filter.h \
 	src/temperature_threshold_manager.c src/temperature_threshold_manager.h \
 	src/optparse/optparse.h src/optparse/optparse.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) src/build.c -o src/nbfc_service $(LDFLAGS) $(CFLAGS_MAIN)
+	$(CC) $(CPPFLAGS) $(CFLAGS) src/build.c -o src/nbfc_service $(LDLIBS) $(LDFLAGS)
 
 src/ec_probe: \
 	src/ec_probe.c \
@@ -122,7 +145,8 @@ src/ec_probe: \
 	src/nbfc.h \
 	src/memory.h src/memory.c \
 	src/optparse/optparse.h src/optparse/optparse.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) src/ec_probe.c -o src/ec_probe $(LDFLAGS) $(CFLAGS_MAIN)
+	$(CC) $(CPPFLAGS) $(CFLAGS) src/ec_probe.c -o src/ec_probe $(LDLIBS) $(LDFLAGS)
+
 src/nbfc: \
 	src/client.c \
 	src/error.h src/error.c \
@@ -130,7 +154,7 @@ src/nbfc: \
 	src/optparse/optparse.h src/optparse/optparse.c \
 	src/nxjson.c src/reverse_nxjson.c src/nxjson.h \
 	src/nbfc.h
-	$(CC) $(CPPFLAGS) $(CFLAGS) src/client.c -o src/nbfc $(LDFLAGS) $(CFLAGS_MAIN)
+	$(CC) $(CPPFLAGS) $(CFLAGS) src/client.c -o src/nbfc $(LDLIBS) $(LDFLAGS)
 
 src/generated/: .force
 	mkdir -p src/generated

--- a/README.md
+++ b/README.md
@@ -55,18 +55,18 @@ It can be queried by `sudo nbfc status -a`.
 If you wish `nbfc_service` to get started on boot, use `sudo systemctl enable nbfc_service`.
 
 
-Differences en detail
+Differences in detail
 ---------------------
 
 |Files                            | NBFC Mono                             | NBFC Linux                                  |
 |---------------------------------|---------------------------------------|----------------------------------------------
 |Systemd service file             | nbfc.service                          | nbfc\_service.service                       |
 |EC Probing tool                  | ec-probe                              | ec\_probe                                   |
-|Notebook configuration files     | /opt/nbfc/Configs/*.xml               | /usr/share/nbfc/configs/*.json              |
-|Service binary                   | /opt/nbfc/nbfcservice.sh              | /bin/nbfc\_service                          |
+|Notebook configuration files     | /opt/nbfc/Configs/*.xml               | /usr/local/share/nbfc/configs/*.json              |
+|Service binary                   | /opt/nbfc/nbfcservice.sh              | /usr/local/bin/nbfc\_service                          |
 |PID File                         | /run/nbfc.pid                         | /run/nbfc\_service.pid                      |
 |State file                       | -                                     | /run/nbfc\_service.state.json               |
-|Config file                      | ?                                     | /etc/nbfc/nbfc.json                         |
+|Config file                      | ?                                     | /usr/local/etc/nbfc/nbfc.json                         |
 
 - The original NBFC service is queried and controlled by the client using TCP/IP. - NBFC Linux does not implement any "real" IPC. Information about the service can be queried by reading its state file. The client controls the service by simply rewriting its configuration file and reloading it.
 
@@ -80,7 +80,7 @@ Troubleshooting
 ---------------
 The preferred way of running nbfc is using the `ECSysLinux` implementation, which depends on the `ec_sys` kernel module.
 There is also an alternative implementation which uses `/dev/port`, called `ec_linux`.
-It can be specified on the commandline using `--embedded-controller=ec_linux` and permanently set in `/etc/nbfc/nbfc.json` with `"EmbeddedControllerType": "ec_linux"`.
+It can be specified on the commandline using `--embedded-controller=ec_linux` and permanently set in `/usr/local/etc/nbfc/nbfc.json` with `"EmbeddedControllerType": "ec_linux"`.
 
 For running NBFC with Secure Boot and Lockdown Kernel, see [acpi\_ec](https://github.com/MusiKid/acpi_ec)
 
@@ -91,7 +91,7 @@ NBFC-Linux comes with shell completion scripts for bash, fish and zsh.
 
 ```
 ~ $ nbfc_service <TAB>
---config-file          -c  -- Use alternative config file (default /etc/nbfc/nbfc.json)
+--config-file          -c  -- Use alternative config file (default /usr/local/etc/nbfc/nbfc.json)
 --debug                -d  -- Enable tracing of reads and writes of the embedded controller
 --embedded-controller  -e  -- Specify embedded controller to use
 --fork                 -f  -- Switch process to background after sucessfully started

--- a/completion/ec_probe.py
+++ b/completion/ec_probe.py
@@ -51,7 +51,7 @@ if man:
             'File containing the PID of current running nbfc_service.',
         '/var/run/nbfc_service.state.json':
             'State file of nbfc_service.\nUpdated every *EcPollInterval* miliseconds See nbfc_service.json(5) for further details.',
-        '/etc/nbfc/configs/*.json':
+        '/usr/local/etc/nbfc/configs/*.json':
             'Configuration files for various notebook models.\nSee nbfc\_service.json(5) for further details.'
     }
 

--- a/completion/fish/nbfc_service.fish
+++ b/completion/fish/nbfc_service.fish
@@ -2,6 +2,6 @@ complete -c nbfc_service -s h -l help -d 'show this help message and exit'
 complete -c nbfc_service -s r -l readonly -d 'Start in read-only mode'
 complete -c nbfc_service -s f -l fork -d 'Switch process to background after sucessfully started'
 complete -c nbfc_service -s d -l debug -d 'Enable tracing of reads and writes of the embedded controller'
-complete -c nbfc_service -r -s c -l config-file -d 'Use alternative config file (default /etc/nbfc/nbfc.json)' -F
+complete -c nbfc_service -r -s c -l config-file -d 'Use alternative config file (default /usr/local/etc/nbfc/nbfc.json)' -F
 complete -c nbfc_service -r -s s -l state-file -d 'Write state to an alternative file (default /var/run/nbfc_service.state.json)' -F
 complete -c nbfc_service -x -s e -l embedded-controller -d 'Specify embedded controller to use' -a 'dummy ec_linux ec_sys_linux'

--- a/completion/nbfc_service.py
+++ b/completion/nbfc_service.py
@@ -3,7 +3,7 @@
 import sys, argparse
 
 #from argany import *
-#a.bash_compgen = 'cd /etc/nbfc/; compgen -f -- $cur'
+#a.bash_compgen = 'cd /usr/local/etc/nbfc/; compgen -f -- $cur'
 
 PROLOG = '''\
 NBFC\_SERVICE 1 "MARCH 2021" Notebook FanControl
@@ -20,7 +20,7 @@ argp = argparse.ArgumentParser(prog='nbfc_service', description='NoteBook FanCon
 argp.add_argument('-r', '--readonly',            help='Start in read-only mode', action='store_true')
 argp.add_argument('-f', '--fork',                help='Switch process to background after sucessfully started', action='store_true')
 argp.add_argument('-d', '--debug',               help='Enable tracing of reads and writes of the embedded controller', action='store_true')
-argp.add_argument('-c', '--config-file',         help='Use alternative config file (default /etc/nbfc/nbfc.json)', metavar='config')
+argp.add_argument('-c', '--config-file',         help='Use alternative config file (default /usr/local/etc/nbfc/nbfc.json)', metavar='config')
 argp.add_argument('-s', '--state-file',          help='Write state to an alternative file (default /var/run/nbfc_service.state.json)', metavar='state.json')
 argp.add_argument('-e', '--embedded-controller', help='Specify embedded controller to use', metavar='EC', choices=['dummy','ec_linux', 'ec_sys_linux'])
 
@@ -35,7 +35,7 @@ FILES
 */var/run/nbfc_service.state.json*
   State file of nbfc\_service. Updated every *EcPollInterval* miliseconds See nbfc\_service.json(5) for further details.
 
-*/etc/nbfc/configs/\*.json*
+*/usr/local/etc/nbfc/configs/\*.json*
   Configuration files for various notebook models. See nbfc\_service.json(5) for further details.
 
 EXIT STATUS

--- a/completion/zsh/_nbfc_service
+++ b/completion/zsh/_nbfc_service
@@ -6,7 +6,7 @@ _nbfc_service() {
     '(--readonly -r)'{--readonly,-r}'[Start in read-only mode]'::'()'\
     '(--fork -f)'{--fork,-f}'[Switch process to background after sucessfully started]'::'()'\
     '(--debug -d)'{--debug,-d}'[Enable tracing of reads and writes of the embedded controller]'::'()'\
-    '(--config-file -c)'{--config-file=,-c+}'[Use alternative config file (default /etc/nbfc/nbfc.json)]':config:_files\
+    '(--config-file -c)'{--config-file=,-c+}'[Use alternative config file (default /usr/local/etc/nbfc/nbfc.json)]':config:_files\
     '(--state-file -s)'{--state-file=,-s+}'[Write state to an alternative file (default /var/run/nbfc_service.state.json)]':'state.json':_files\
     '(--embedded-controller -e)'{--embedded-controller=,-e+}'[Specify embedded controller to use]':EC:'(dummy ec_linux ec_sys_linux)'
 }

--- a/doc/README.md
+++ b/doc/README.md
@@ -121,10 +121,10 @@ FILES
 */var/run/nbfc_service.state.json*
   State file of nbfc\_service. Updated every *EcPollInterval* miliseconds See nbfc\_service.json(5) for further details.
 
-*/etc/nbfc/nbfc.json*
+*/usr/local/etc/nbfc/nbfc.json*
   The system wide configuration file. See nbfc\_service.json(5) for further details.
 
-*/etc/nbfc/configs/\*.json*
+*/usr/local/etc/nbfc/configs/\*.json*
   Configuration files for various notebook models. See nbfc\_service.json(5) for further details.
 
 BUGS

--- a/doc/nbfc.1
+++ b/doc/nbfc.1
@@ -190,11 +190,11 @@ Show help
   State file of nbfc\_service. Updated every \fIEcPollInterval\fP miliseconds See nbfc\_service.json(5) for further details.
 
 .PP
-\fI/etc/nbfc/nbfc.json\fP
+\fI/usr/local/etc/nbfc/nbfc.json\fP
   The system wide configuration file. See nbfc\_service.json(5) for further details.
 
 .PP
-\fI/etc/nbfc/configs/*\&.json\fP
+\fI/usr/local/etc/nbfc/configs/*\&.json\fP
   Configuration files for various notebook models. See nbfc\_service.json(5) for further details.
 
 .SH BUGS

--- a/doc/nbfc.md
+++ b/doc/nbfc.md
@@ -121,10 +121,10 @@ FILES
 */var/run/nbfc_service.state.json*
   State file of nbfc\_service. Updated every *EcPollInterval* miliseconds See nbfc\_service.json(5) for further details.
 
-*/usr/share/nbfc/nbfc.json*
+*/usr/local/share/nbfc/nbfc.json*
   The system wide configuration file. See [nbfc\_service.json(5)](nbfc_service.json.md) for further details.
 
-*/etc/nbfc/configs/\*.json*
+*/usr/local/etc/nbfc/configs/\*.json*
   Configuration files for various notebook models. See [nbfc\_service.json(5)](nbfc_service.json.md) for further details.
 
 BUGS

--- a/doc/nbfc_service.1
+++ b/doc/nbfc_service.1
@@ -31,7 +31,7 @@ NoteBook FanControl service
 
 .PP
 \fB\fC\-c, \-\-config\-file config\fR
-    Use alternative config file (default /etc/nbfc/nbfc.json)
+    Use alternative config file (default /usr/local/etc/nbfc/nbfc.json)
 
 .PP
 \fB\fC\-s, \-\-state\-file state.json\fR
@@ -51,7 +51,7 @@ NoteBook FanControl service
   State file of nbfc\_service. Updated every \fIEcPollInterval\fP miliseconds See nbfc\_service.json(5) for further details.
 
 .PP
-\fI/etc/nbfc/configs/*\&.json\fP
+\fI/usr/local/etc/nbfc/configs/*\&.json\fP
   Configuration files for various notebook models. See nbfc\_service.json(5) for further details.
 
 .SH EXIT STATUS

--- a/doc/nbfc_service.json.5
+++ b/doc/nbfc_service.json.5
@@ -209,11 +209,11 @@ Defines how fast the fan runs at different temperatures
   State file of nbfc\_service. Updated every \fIEcPollInterval\fP miliseconds.
 
 .PP
-\fI/etc/nbfc/nbfc.json\fP
+\fI/usr/local/etc/nbfc/nbfc.json\fP
   The system wide configuration file.
 
 .PP
-\fI/etc/nbfc/configs/*\&.json\fP
+\fI/usr/local/etc/nbfc/configs/*\&.json\fP
   Configuration files for various notebook models.
 
 .SH AUTHOR

--- a/doc/nbfc_service.json.md
+++ b/doc/nbfc_service.json.md
@@ -181,10 +181,10 @@ FILES
 */var/run/nbfc_service.state.json*
   State file of nbfc\_service. Updated every *EcPollInterval* miliseconds.
 
-*/etc/nbfc/nbfc.json*
+*/usr/local/etc/nbfc/nbfc.json*
   The system wide configuration file.
 
-*/usr/share/nbfc/configs/\*.json*
+*/usr/local/share/nbfc/configs/\*.json*
   Configuration files for various notebook models.
 
 AUTHOR

--- a/doc/nbfc_service.md
+++ b/doc/nbfc_service.md
@@ -32,7 +32,7 @@ OPTIONS
     Enable tracing of reads and writes of the embedded controller
 
   `-c, --config-file config`
-    Use alternative config file (default /etc/nbfc/nbfc.json)
+    Use alternative config file (default /usr/local/etc/nbfc/nbfc.json)
 
   `-s, --state-file state.json`
     Write state to an alternative file (default /var/run/nbfc_service.state.json)
@@ -50,7 +50,7 @@ FILES
 */var/run/nbfc_service.state.json*
   State file of nbfc\_service. Updated every *EcPollInterval* miliseconds See [nbfc\_service.json(5)](nbfc_service.json.md) for further details.
 
-*/usr/share/nbfc/configs/\*.json*
+*/usr/local/share/nbfc/configs/\*.json*
   Configuration files for various notebook models. See [nbfc\_service.json(5)](nbfc_service.json.md) for further details.
 
 EXIT STATUS

--- a/etc/systemd/system/nbfc_service.service
+++ b/etc/systemd/system/nbfc_service.service
@@ -2,9 +2,9 @@
 Description=NoteBook FanControl service
 
 [Service]
-ExecStartPre=/usr/bin/nbfc wait-for-hwmon
-ExecStart=/usr/bin/nbfc start
-ExecStop=-/usr/bin/nbfc stop
+ExecStartPre=/usr/local/bin/nbfc wait-for-hwmon
+ExecStart=/usr/local/bin/nbfc start
+ExecStop=/usr/local/bin/nbfc stop
 Type=forking
 PIDFile=/var/run/nbfc_service.pid
 TimeoutStopSec=20
@@ -12,4 +12,3 @@ Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target
-

--- a/nbfc.py
+++ b/nbfc.py
@@ -35,9 +35,9 @@ def get_system_product():
     return dmidecode_bin_get_system_product()
 
 class NbfcService:
-    CONFIG_DIR  = '/etc/nbfc'
-    CONFIGS_DIR = '/usr/share/nbfc/configs'
-    CONFIG_FILE = '/etc/nbfc/nbfc.json'
+    CONFIG_DIR  = '/usr/local/etc/nbfc'
+    CONFIGS_DIR = '/usr/local/share/nbfc/configs'
+    CONFIG_FILE = '/usr/local/etc/nbfc/nbfc.json'
     STATE_FILE  = '/var/run/nbfc_service.state.json'
     PID_FILE    = '/var/run/nbfc_service.pid'
 

--- a/nbfc.py
+++ b/nbfc.py
@@ -319,10 +319,10 @@ FILES
 */var/run/nbfc_service.state.json*
   State file of nbfc\_service. Updated every *EcPollInterval* miliseconds See nbfc\_service.json(5) for further details.
 
-*/etc/nbfc/nbfc.json*
+*/usr/local/etc/nbfc/nbfc.json*
   The system wide configuration file. See nbfc\_service.json(5) for further details.
 
-*/etc/nbfc/configs/\*.json*
+*/usr/local/etc/nbfc/configs/\*.json*
   Configuration files for various notebook models. See nbfc\_service.json(5) for further details.
 
 BUGS

--- a/src/generated/nbfc_service.help.h
+++ b/src/generated/nbfc_service.help.h
@@ -8,7 +8,7 @@
  "  -f, --fork            Switch process to background after sucessfully started\n"\
  "  -d, --debug           Enable tracing of reads and writes of the embedded controller\n"\
  "  -c config, --config-file config\n"\
- "                        Use alternative config file (default /etc/nbfc/nbfc.json)\n"\
+ "                        Use alternative config file (default /usr/local/etc/nbfc/nbfc.json)\n"\
  "  -s state.json, --state-file state.json\n"\
  "                        Write state to an alternative file (default /var/run/nbfc_service.state.json)\n"\
  "  -e EC, --embedded-controller EC\n"\

--- a/tools/config_to_md.py
+++ b/tools/config_to_md.py
@@ -35,10 +35,10 @@ FILES
 */var/run/nbfc_service.state.json*
   State file of nbfc\_service. Updated every *EcPollInterval* miliseconds.
 
-*/etc/nbfc/nbfc.json*
+*/usr/local/etc/nbfc/nbfc.json*
   The system wide configuration file.
 
-*/etc/nbfc/configs/\*.json*
+*/usr/local/etc/nbfc/configs/\*.json*
   Configuration files for various notebook models.
 
 AUTHOR


### PR DESCRIPTION
### Makefile
- added -lm as it is required to build successfully.
- added simple conditional to allow 'make BUILD=debug' for a debug build, else default to a release build. This uses the original values from the old src/Makefile, but experienced users can still override these if they wish.
- added install-c target which installs nbfc-linux with the C client, so users no longer need to manually edit the Makefile.
- added new libdir definition for installing systemd service file under /usr/local/.
- changed uninstall target so that it force removes files, ensuring that it doesn't exit with Error in the slim (but real) chance that one of the files were manually removed.

### Further changes
updated systemd service file to account for /usr/local prefix in Makefile.
updated python client to account for /usr/local prefix in Makefile.
updated supporting documentation with new /usr/local prefix.

